### PR TITLE
Add logic to function that saves current poster only once

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -193,5 +193,7 @@ function saveUserInputs() {
 }
 
 function saveMyPoster() {
-  savedPosters.push(currentPoster);
+  if (!savedPosters.includes(currentPoster)) {
+    savedPosters.push(currentPoster);
+  }
 }


### PR DESCRIPTION
Added a few new lines of code that include logic for the saveMyPoster function. Now, it should only save the current poster once. If the savedPosters array already includes the current poster, it won't save it again. (No duplicates.)