### PR TITLE
Readme instructions pt one/kw

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,12 @@ When you click the Show Saved Posters button, it will take you to the saved post
 
 <img width="1440" alt="saved-view-empty" src="https://user-images.githubusercontent.com/79027364/145722654-d7a44bde-e2f6-4d92-be50-c912158dfe71.png">
 
-Clicking on the Make Your Own Poster button will take you to a form that contains fields to enter an image URL, title, and quote for your custom poster. Show my poster will bring you back to the main page view with your custom poster displayed. If you decide not to create your own poster, you can click on the Nevermind button and go back to the main page without filling out the form.
+Clicking on the Make Your Own Poster button will take you to a form that contains fields to enter an image URL, title, and quote for your custom poster. If you decide not to create your own poster, you can click on the Nevermind button and go back to the main page without filling out the form.
 
 <img width="1440" alt="form-view" src="https://user-images.githubusercontent.com/79027364/145722609-f4e5e3a1-2b04-4609-a771-e677d44666fb.png">
+
+#### Part 3: Make a Custom Poster
+
+On the poster form, fill in the three fields with your desired text and image URL. Show my poster will bring you back to the main page view with your custom poster displayed. It will also save your submitted data so that you can use it for future random posters.
 
 <img width="1440" alt="create-poster" src="https://user-images.githubusercontent.com/79027364/145722632-c2d6ab62-3bb8-45a1-80a9-e711bb2116ab.png">

--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ This site was built using JavaScript, HTML, and CSS. There are three views for t
 - Make Your Own Poster page
 - Saved Posters page
 
-
 #### Contributors
 This site was built by [Kim Ward](https://github.com/kmewrd) and [Andrew Musselman](https://github.com/Andrew-Musselman) as a pair project at Turing School of Software & Design.
 
+## Step-by-Step Guide
+#### Part 1: Main Page
+The site can be opened at [this link](https://andrew-musselman.github.io/motivate-me/). On load, you will see the main page and a poster with a randomly selected image, title, and quote.
+
 <img width="1440" alt="main-page" src="https://user-images.githubusercontent.com/79027364/145722550-9324f6c6-8ae4-4f37-9cc2-2c7071fce44e.png">
+
+Every time the Show Another Random Poster button is clicked, a new random poster will be displayed.
 
 <img width="1440" alt="saved-view-empty" src="https://user-images.githubusercontent.com/79027364/145722654-d7a44bde-e2f6-4d92-be50-c912158dfe71.png">
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Motivate Me
-This is a paired project for a website that generates motivational posters. This site will allow you to generate a random poster or create your own. Additionally, you have the option to save posters or delete posters from a collection.
+Motivational poster creator. This site will allow you to generate a random poster or make your own. When you create your own poster, it saves the submitted data so that future posters can use it. Additionally, you have the option to save posters, delete posters from a collection, and replace individual elements (image, title, quote) on your main poster.
 
-This site is built using JavaScript, HTML, and CSS. There are three views for this page:
+#### Tech
+
+This site was built using JavaScript, HTML, and CSS. There are three views for this page:
 - Main page
-- Make Your Own page
+- Make Your Own Poster page
 - Saved Posters page
 
 #### Contributors
-- [Kim Ward](https://github.com/kmewrd)
-- [Andrew Musselman](https://github.com/Andrew-Musselman)
+This site was built by [Kim Ward](https://github.com/kmewrd) and [Andrew Musselman](https://github.com/Andrew-Musselman) as a pair project at Turing School of Software & Design.
 
 ## To be deleted later...
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ The site can be opened at [this link](https://andrew-musselman.github.io/motivat
 
 Every time the Show Another Random Poster button is clicked, a new random poster will be displayed.
 
+#### Part 2: Switching Page View
+When you click the Show Saved Posters button, it will take you to the saved posters area. The Back to Main button takes you back to the main page.
+
 <img width="1440" alt="saved-view-empty" src="https://user-images.githubusercontent.com/79027364/145722654-d7a44bde-e2f6-4d92-be50-c912158dfe71.png">
+
+Clicking on the Make Your Own Poster button will take you to a form that contains fields to enter an image URL, title, and quote for your custom poster. Show my poster will bring you back to the main page view with your custom poster displayed. If you decide not to create your own poster, you can click on the Nevermind button and go back to the main page without filling out the form.
 
 <img width="1440" alt="form-view" src="https://user-images.githubusercontent.com/79027364/145722609-f4e5e3a1-2b04-4609-a771-e677d44666fb.png">
 

--- a/README.md
+++ b/README.md
@@ -8,5 +8,14 @@ This site was built using JavaScript, HTML, and CSS. There are three views for t
 - Make Your Own Poster page
 - Saved Posters page
 
+
 #### Contributors
 This site was built by [Kim Ward](https://github.com/kmewrd) and [Andrew Musselman](https://github.com/Andrew-Musselman) as a pair project at Turing School of Software & Design.
+
+<img width="1440" alt="main-page" src="https://user-images.githubusercontent.com/79027364/145722550-9324f6c6-8ae4-4f37-9cc2-2c7071fce44e.png">
+
+<img width="1440" alt="saved-view-empty" src="https://user-images.githubusercontent.com/79027364/145722654-d7a44bde-e2f6-4d92-be50-c912158dfe71.png">
+
+<img width="1440" alt="form-view" src="https://user-images.githubusercontent.com/79027364/145722609-f4e5e3a1-2b04-4609-a771-e677d44666fb.png">
+
+<img width="1440" alt="create-poster" src="https://user-images.githubusercontent.com/79027364/145722632-c2d6ab62-3bb8-45a1-80a9-e711bb2116ab.png">

--- a/README.md
+++ b/README.md
@@ -10,12 +10,3 @@ This site was built using JavaScript, HTML, and CSS. There are three views for t
 
 #### Contributors
 This site was built by [Kim Ward](https://github.com/kmewrd) and [Andrew Musselman](https://github.com/Andrew-Musselman) as a pair project at Turing School of Software & Design.
-
-## To be deleted later...
-
-Project spec & rubric can be found [here](https://frontend.turing.io/projects/module-1/hang-in-there.html)
-
-To view your project:
-
-1. In your terminal, navigate to your project repo
-2. Run the command `open index.html`


### PR DESCRIPTION
The first half of the readme file has been updated. This includes the short description, tech, and contributors section. I've also added instructions for how to use the main page, switch page view, and make a custom poster. Look it over and let me know what you think. If it looks good we can merge this PR first, then merge yours later with the second half of the readme updated. If you've already started working on it there will be a merge conflict, but we can cross that bridge when we get on a call later.

Note: For some reason I can create a space between a paragraph and an image, but not a space below the image. Must be a markdown quirk?